### PR TITLE
Specify IP address to bind.

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -3,7 +3,8 @@ var https = require('https');
 var Router = require('detour').Router;
 var _ = require('underscore');
 
-var Server = function(port, protocol, resourcePath){
+var Server = function(ip, port, protocol, resourcePath){
+  this.ip = ip || '0.0.0.0';
   this.port = port || 5000;
   this.protocol = protocol || 'http';
   this.resourcePath = resourcePath || '/';
@@ -122,7 +123,7 @@ Server.prototype.listen = function(cb){
     });
     router.dispatch({req : req, res : res});
   });
-  coreServer.listen(that.port, cb);
+  coreServer.listen(that.port, that.ip, cb);
   that.coreServer = coreServer;
 };
 

--- a/test/Server.js
+++ b/test/Server.js
@@ -19,6 +19,7 @@ function closeServer(server, cb){
 describe('Server', function(){
   beforeEach(function(done){
     this.port = 3000;
+    this.ip = '0.0.0.0';
     if (!this.server){ 
       this.server = null;
     }
@@ -31,7 +32,7 @@ describe('Server', function(){
   it("has default error handlers for 404s", function(done){
     var that = this;
     var url = "http://localhost:3000/DOES_NOT_EXIST";
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World!");
                                            }});
@@ -51,7 +52,7 @@ describe('Server', function(){
   it("sets the server header by default", function(done){
     var that = this;
     var url = "http://localhost:3000/";
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World!");
                                            }});
@@ -72,7 +73,7 @@ describe('Server', function(){
   it("allows override of server header", function(done){
     var that = this;
     var url = "http://localhost:3000/";
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.setDefaultResponseHeader('server', 'IIS 4.0 WIN NT. Fo realz');
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World!");
@@ -93,7 +94,7 @@ describe('Server', function(){
   it("allows setting default response headers", function(done){
     var that = this;
     var url = "http://localhost:3000/";
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.setDefaultResponseHeader('X-Made-this-up', '1337');
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World!");
@@ -115,7 +116,7 @@ describe('Server', function(){
   it("has default error handlers for 405s", function(done){
     var that = this;
     var url = "http://localhost:3000/";
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World!");
                                            }});
@@ -135,7 +136,7 @@ describe('Server', function(){
   it("has default error handlers for 501s", function(done){
     var that = this;
     var url = "http://localhost:3000/";
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World!");
                                            }});
@@ -157,7 +158,7 @@ describe('Server', function(){
     var bigpath = "1";
     _.times(4097, function(){bigpath += '1';});
     var url = "http://localhost:3000/" + bigpath;
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World!");
                                            }});
@@ -178,7 +179,7 @@ describe('Server', function(){
   it ("exposes an onRequest hook for additionally handling requests", function(done){
     var that = this;
     var url = "http://localhost:3000/";
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World! " + $.decorated);
                                            }});
@@ -202,7 +203,7 @@ describe('Server', function(){
 
   it ("can respond to simple requests", function(done){
     var that = this;
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World!");
                                            }});
@@ -225,7 +226,7 @@ describe('Server', function(){
 
   it ("adds a router reference to every context", function(done){
     var that = this;
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                              //should.exist($.router);
                                              $.res.end("Hello World!");
@@ -248,7 +249,7 @@ describe('Server', function(){
 
   it ("HEAD for a GET-only resource returns the same headers, blank resource", function(done){
     var that = this;
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                        $.res.setHeader('Content-Type', 'text/plain');
                                        $.res.end('yo yo yo');
@@ -273,7 +274,7 @@ describe('Server', function(){
 
   it ("OPTIONS for a GET-only resource returns, GET, HEAD, OPTIONS", function(done){
     var that = this;
-    this.server = new Server(3000);
+    this.server = new Server('0.0.0.0', 3000);
     this.server.route('/', {  GET : function($){
                                              $.res.end("Hello World!");
                                            }});


### PR DESCRIPTION
Defaults to 0.0.0.0 preserving original no-arguments behavior. Will require a change in downstream apps as this is the first argument.

Could try and change function signature so that by default new Serve takes a proplist of arguments but preserves the original three argument signature. If percolator is the only thing using oneone then no real need...
